### PR TITLE
[#24] Feat: 음악 정지 기능

### DIFF
--- a/src/main/java/discord/podongbot/music/PlayerManager.java
+++ b/src/main/java/discord/podongbot/music/PlayerManager.java
@@ -158,6 +158,7 @@ public class PlayerManager {
         PlayerManager.getINSTANCE().loadAndPlay(event.getChannel().asTextChannel(), link);
     }
 
+    // 대기열 관리
     public static void handleQueueCommand(SlashCommandInteractionEvent event) {
         Guild guild = event.getGuild();
         if (guild == null) return;
@@ -176,6 +177,8 @@ public class PlayerManager {
 
         event.reply("현재 대기열:\n" + queueList).queue();
     }
+
+    // 음악 일시정지
     public static void handleTogglePauseCommand(SlashCommandInteractionEvent event) {
         Guild guild = event.getGuild();
         if (guild == null) return;
@@ -201,5 +204,30 @@ public class PlayerManager {
             event.reply("⏸\uFE0F 음악을 일시정지했습니다!").queue();
         }
     }
+
+    // 음악 정지
+    public static void handleStopCommand(SlashCommandInteractionEvent event) {
+        Guild guild = event.getGuild();
+        if (guild == null) return;
+
+        GuildMusicManager musicManager = getINSTANCE().getMusicManager(guild);
+
+        // 현재 재생 중인지 확인
+        if (musicManager.audioPlayer.getPlayingTrack() == null && musicManager.scheduler.getQueue().isEmpty()) {
+            event.reply("⚠\uFE0F 음악이 재생되고 있지 않습니다!").queue();
+            return;
+        }
+
+        // 음악 정지 및 대기열 초기화
+        musicManager.audioPlayer.stopTrack();
+        musicManager.scheduler.getQueue().clear();
+
+        // 음성 채널에서 봇 나가기
+        guild.getAudioManager().closeAudioConnection();
+
+        // 메시지 출력
+        event.reply("⛔ 음악이 끝났습니다!").queue();
+    }
+
 
 }

--- a/src/main/java/discord/podongbot/music/PlayerManager.java
+++ b/src/main/java/discord/podongbot/music/PlayerManager.java
@@ -15,9 +15,11 @@ import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.stream.Collectors;
 
 // 서버별 GuildMusicManager를 중앙에서 관리
@@ -218,9 +220,18 @@ public class PlayerManager {
             return;
         }
 
-        // 음악 정지 및 대기열 초기화
+        // 음악 정지
         musicManager.audioPlayer.stopTrack();
-        musicManager.scheduler.getQueue().clear();
+
+        // Lavaplayer 내부 queue를 강제로 초기화
+        try {
+            Field queueField = musicManager.scheduler.getClass().getDeclaredField("queue");
+            queueField.setAccessible(true);
+            queueField.set(musicManager.scheduler, new LinkedBlockingQueue<>()); // 새로운 빈 대기열 설정
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            event.getHook().sendMessage("🚨 대기열 초기화 중 오류 발생!").queue();
+            return;
+        }
 
         // 음성 채널에서 봇 나가기
         guild.getAudioManager().closeAudioConnection();

--- a/src/main/java/discord/podongbot/response/SlashCommandReaction.java
+++ b/src/main/java/discord/podongbot/response/SlashCommandReaction.java
@@ -38,8 +38,11 @@ public class SlashCommandReaction extends ListenerAdapter {
             case "대기열":
                 PlayerManager.handleQueueCommand(event);
                 break;
-            case "중지":
+            case "일시정지":
                 PlayerManager.handleTogglePauseCommand(event);
+                break;
+            case "정지":
+                PlayerManager.handleStopCommand(event);
                 break;
         }
     }
@@ -67,7 +70,10 @@ public class SlashCommandReaction extends ListenerAdapter {
                 Commands.slash("대기열", "현재 대기열을 보여줍니다.")
         );
         commandDatas.add(
-                Commands.slash("중지", "음악을 일시정지합니다.")
+                Commands.slash("일시정지", "음악을 일시정지합니다.")
+        );
+        commandDatas.add(
+                Commands.slash("정지", "모든 플레이어를 초기화합니다.")
         );
         event.getGuild().updateCommands().addCommands(commandDatas).queue();
     }


### PR DESCRIPTION
## 📝 작업 내용
> 음악 정지 기능
```java
musicManager.scheduler.getQueue().clear();
``` 
대기열을 초기화하기 위해 이 코드를 사용하였으나, Lavaplayer의 BlockingQueue는 비동기적이라 clear()가 즉시 적용되지 않는 문제 발생 -> /정지 실행하고 /대기열 실행하면 비어있어야 할 대기열이 정지하기 전 등록했던 음악 리스트가 그대로 유지.
😃 Lavaplayer 내부 queue를 강제로 초기화하는 방식으로 변경(새로운 queue 필드로 교체)

## 🔍 테스트 방법
> /정지 실행하면 재생되고 있던 음악과 대기열이 모두 초기화되고 봇이 음성채널에서 나감.
![image](https://github.com/user-attachments/assets/4eba5c2d-06c1-4539-8b25-dfb1514f3f3b)
