### PR TITLE
[#26] Feat: 음악 반복/셔플 기능

### DIFF
--- a/src/main/java/discord/podongbot/music/GuildMusicManager.java
+++ b/src/main/java/discord/podongbot/music/GuildMusicManager.java
@@ -4,6 +4,7 @@ import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
 import discord.podongbot.volume.VolumeControl;
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 
 // 서버별로 플레이어와 트랙 관리를 담당
 public class GuildMusicManager {
@@ -12,10 +13,11 @@ public class GuildMusicManager {
     private final AudioPlayerSendHandler sendHandler;
     private final VolumeControl volumeControl;
 
-    public GuildMusicManager(AudioPlayerManager manager, Guild guild) {
+    public GuildMusicManager(AudioPlayerManager manager, Guild guild, TextChannel textChannel) {
         this.audioPlayer = manager.createPlayer();
         this.scheduler = new TrackScheduler(this.audioPlayer, guild);
         this.audioPlayer.addListener(this.scheduler);
+        this.scheduler.setTextChannel(textChannel);
         this.sendHandler = new AudioPlayerSendHandler(this.audioPlayer);
         this.volumeControl = new VolumeControl(this.audioPlayer);
 

--- a/src/main/java/discord/podongbot/music/GuildMusicManager.java
+++ b/src/main/java/discord/podongbot/music/GuildMusicManager.java
@@ -3,6 +3,7 @@ package discord.podongbot.music;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
 import discord.podongbot.volume.VolumeControl;
+import net.dv8tion.jda.api.entities.Guild;
 
 // 서버별로 플레이어와 트랙 관리를 담당
 public class GuildMusicManager {
@@ -11,9 +12,9 @@ public class GuildMusicManager {
     private final AudioPlayerSendHandler sendHandler;
     private final VolumeControl volumeControl;
 
-    public GuildMusicManager(AudioPlayerManager manager) {
+    public GuildMusicManager(AudioPlayerManager manager, Guild guild) {
         this.audioPlayer = manager.createPlayer();
-        this.scheduler = new TrackScheduler(this.audioPlayer);
+        this.scheduler = new TrackScheduler(this.audioPlayer, guild);
         this.audioPlayer.addListener(this.scheduler);
         this.sendHandler = new AudioPlayerSendHandler(this.audioPlayer);
         this.volumeControl = new VolumeControl(this.audioPlayer);

--- a/src/main/java/discord/podongbot/music/PlayerManager.java
+++ b/src/main/java/discord/podongbot/music/PlayerManager.java
@@ -16,9 +16,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 
 import java.lang.reflect.Field;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.stream.Collectors;
 
@@ -274,6 +272,34 @@ public class PlayerManager {
         } else {
             event.reply("❌ 잘못된 입력입니다. `/반복 0`, `/반복 1`, `/반복 2` 중 하나를 입력해주세요.").queue();
         }
+    }
+
+    // 음악 셔플
+    public static void handleShuffleCommand(SlashCommandInteractionEvent event) {
+        Guild guild = event.getGuild();
+        if (guild == null) return;
+
+        TextChannel textChannel = event.getChannel().asTextChannel();
+        GuildMusicManager musicManager = getINSTANCE().getMusicManager(guild, textChannel);
+        TrackScheduler scheduler = musicManager.scheduler;
+
+        List<AudioTrack> queue = scheduler.getQueue();
+        if (queue.isEmpty()) {
+            event.reply("⚠\uFE0F 음악이 재생되고 있지 않습니다!").queue();
+            return;
+        }
+
+        // 현재 재생 중인 곡을 포함하여 셔플하기 위해 새로운 리스트 생성
+        List<AudioTrack> shuffledQueue = new ArrayList<>(queue);
+        if (musicManager.audioPlayer.getPlayingTrack() != null) {
+            shuffledQueue.add(0, musicManager.audioPlayer.getPlayingTrack());
+        }
+
+        Collections.shuffle(shuffledQueue); // 랜덤 셔플
+
+        // 셔플된 큐를 다시 설정
+        scheduler.setQueue(shuffledQueue);
+        event.reply("🔀 대기열이 셔플되었습니다!").queue();
     }
 
 

--- a/src/main/java/discord/podongbot/music/PlayerManager.java
+++ b/src/main/java/discord/podongbot/music/PlayerManager.java
@@ -256,6 +256,12 @@ public class PlayerManager {
         GuildMusicManager musicManager = getINSTANCE().getMusicManager(guild, textChannel);
         TrackScheduler scheduler = musicManager.scheduler;
 
+        // 현재 재생 중인지 확인
+        if (musicManager.audioPlayer.getPlayingTrack() == null && musicManager.scheduler.getQueue().isEmpty()) {
+            event.reply("⚠\uFE0F 음악이 재생되고 있지 않습니다!").queue();
+            return;
+        }
+
         if (mode == 0) {
             scheduler.setRepeatMode(0);
             event.reply("🔁 반복이 비활성화되었습니다.").queue();

--- a/src/main/java/discord/podongbot/music/PlayerManager.java
+++ b/src/main/java/discord/podongbot/music/PlayerManager.java
@@ -240,5 +240,28 @@ public class PlayerManager {
         event.reply("⛔ 음악이 끝났습니다!").queue();
     }
 
+    // 음악 반복
+    public static void handleRepeatCommand(SlashCommandInteractionEvent event, int mode) {
+        Guild guild = event.getGuild();
+        if (guild == null) return;
+
+        GuildMusicManager musicManager = getINSTANCE().getMusicManager(guild);
+        TrackScheduler scheduler = musicManager.scheduler;
+
+        if (mode == 0) {
+            scheduler.setRepeatMode(0);
+            event.reply("🔁 반복이 비활성화되었습니다.").queue();
+        } else if (mode == 1) {
+            scheduler.setRepeatMode(1);
+            event.reply("🔂 현재 재생 중인 음악이 반복됩니다.").queue();
+        } else if (mode == 2) {
+            scheduler.setRepeatMode(2);
+            event.reply("🔁 대기열의 모든 음악이 반복됩니다.").queue();
+        } else {
+            event.reply("❌ 잘못된 입력입니다. `/반복 0`, `/반복 1`, `/반복 2` 중 하나를 입력해주세요.").queue();
+        }
+    }
+
+
 
 }

--- a/src/main/java/discord/podongbot/music/PlayerManager.java
+++ b/src/main/java/discord/podongbot/music/PlayerManager.java
@@ -289,12 +289,7 @@ public class PlayerManager {
             return;
         }
 
-        // 현재 재생 중인 곡을 포함하여 셔플하기 위해 새로운 리스트 생성
         List<AudioTrack> shuffledQueue = new ArrayList<>(queue);
-        if (musicManager.audioPlayer.getPlayingTrack() != null) {
-            shuffledQueue.add(0, musicManager.audioPlayer.getPlayingTrack());
-        }
-
         Collections.shuffle(shuffledQueue); // 랜덤 셔플
 
         // 셔플된 큐를 다시 설정

--- a/src/main/java/discord/podongbot/music/PlayerManager.java
+++ b/src/main/java/discord/podongbot/music/PlayerManager.java
@@ -54,7 +54,7 @@ public class PlayerManager {
 
     public GuildMusicManager getMusicManager(Guild guild) {
         return this.musicManagers.computeIfAbsent(guild.getIdLong(), (guildId) -> {
-            final GuildMusicManager guildMusicManager = new GuildMusicManager(this.audioPlayerManager);
+            final GuildMusicManager guildMusicManager = new GuildMusicManager(this.audioPlayerManager, guild);
             guild.getAudioManager().setSendingHandler(guildMusicManager.getSendHandler());
             return guildMusicManager;
         });

--- a/src/main/java/discord/podongbot/music/TrackScheduler.java
+++ b/src/main/java/discord/podongbot/music/TrackScheduler.java
@@ -5,6 +5,7 @@ import com.sedmelluq.discord.lavaplayer.player.event.AudioEventAdapter;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason;
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.managers.AudioManager;
 
 import java.util.List;
@@ -17,6 +18,7 @@ public class TrackScheduler extends AudioEventAdapter {
     private final AudioPlayer audioPlayer;
     private final BlockingQueue<AudioTrack> queue;
     private final Guild guild;
+    private TextChannel textChannel;
     private int repeatMode = 0; // 0: 반복 없음, 1: 현재 트랙 반복, 2: 대기열 전체 반복
 
     public TrackScheduler(AudioPlayer audioPlayer, Guild guild) {
@@ -67,10 +69,17 @@ public class TrackScheduler extends AudioEventAdapter {
         this.repeatMode = mode;
     }
 
+    public void setTextChannel(TextChannel textChannel) {
+        this.textChannel = textChannel;
+    }
+
     private void leaveVoiceChannel() {
         AudioManager audioManager = guild.getAudioManager();
         if (audioManager.isConnected()) {
             audioManager.closeAudioConnection();
+            if(textChannel != null) {
+                textChannel.sendMessage("⛔ 음악이 끝났습니다!").queue();
+            }
         }
     }
 }

--- a/src/main/java/discord/podongbot/music/TrackScheduler.java
+++ b/src/main/java/discord/podongbot/music/TrackScheduler.java
@@ -82,4 +82,9 @@ public class TrackScheduler extends AudioEventAdapter {
             }
         }
     }
+
+    public void setQueue(List<AudioTrack> newQueue) {
+        this.queue.clear();
+        this.queue.addAll(newQueue);
+    }
 }

--- a/src/main/java/discord/podongbot/response/SlashCommandReaction.java
+++ b/src/main/java/discord/podongbot/response/SlashCommandReaction.java
@@ -44,6 +44,10 @@ public class SlashCommandReaction extends ListenerAdapter {
             case "정지":
                 PlayerManager.handleStopCommand(event);
                 break;
+            case "반복":
+                int mode = event.getOption("mode").getAsInt();
+                PlayerManager.handleRepeatCommand(event, mode);
+                break;
         }
     }
 
@@ -74,6 +78,10 @@ public class SlashCommandReaction extends ListenerAdapter {
         );
         commandDatas.add(
                 Commands.slash("정지", "모든 플레이어를 초기화합니다.")
+        );
+        commandDatas.add(
+                Commands.slash("반복", "반복 모드를 설정합니다.")
+                        .addOption(OptionType.INTEGER, "mode", "반복 모드 (0: 반복 없음, 1: 현재 트랙 반복, 2: 대기열 전체 반복)", true)
         );
         event.getGuild().updateCommands().addCommands(commandDatas).queue();
     }

--- a/src/main/java/discord/podongbot/response/SlashCommandReaction.java
+++ b/src/main/java/discord/podongbot/response/SlashCommandReaction.java
@@ -48,6 +48,9 @@ public class SlashCommandReaction extends ListenerAdapter {
                 int mode = event.getOption("mode").getAsInt();
                 PlayerManager.handleRepeatCommand(event, mode);
                 break;
+            case "셔플":
+                PlayerManager.handleShuffleCommand(event);
+                break;
         }
     }
 
@@ -82,6 +85,9 @@ public class SlashCommandReaction extends ListenerAdapter {
         commandDatas.add(
                 Commands.slash("반복", "반복 모드를 설정합니다.")
                         .addOption(OptionType.INTEGER, "mode", "반복 모드 (0: 반복 없음, 1: 현재 트랙 반복, 2: 대기열 전체 반복)", true)
+        );
+        commandDatas.add(
+                Commands.slash("셔플", "모든 곡의 순서를 섞습니다.")
         );
         event.getGuild().updateCommands().addCommands(commandDatas).queue();
     }

--- a/src/main/java/discord/podongbot/volume/VolumeControl.java
+++ b/src/main/java/discord/podongbot/volume/VolumeControl.java
@@ -3,8 +3,11 @@ package discord.podongbot.volume;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
 import discord.podongbot.music.GuildMusicManager;
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import discord.podongbot.music.PlayerManager;
+
+import javax.swing.text.TabExpander;
 
 // 음악 볼륨을 조절하는 클래스
 public class VolumeControl {
@@ -24,13 +27,14 @@ public class VolumeControl {
         this.audioPlayer.setVolume(volume);
     }
 
-    public static VolumeControl getVolumeControl(Guild guild) {
-        GuildMusicManager musicManager = PlayerManager.getINSTANCE().getMusicManager(guild);
+    public static VolumeControl getVolumeControl(Guild guild, TextChannel textChannel) {
+        GuildMusicManager musicManager = PlayerManager.getINSTANCE().getMusicManager(guild, textChannel);
         return musicManager.getVolumeControl();
     }
 
     public static void handleVolumeCommand(SlashCommandInteractionEvent event) {
         Guild guild = event.getGuild();
+        TextChannel textChannel = event.getChannel().asTextChannel();
         if (guild == null) {
             event.reply("이 명령어는 서버에서만 사용할 수 있습니다.").setEphemeral(true).queue();
             return;
@@ -48,7 +52,7 @@ public class VolumeControl {
             return;
         }
 
-        VolumeControl volumeControl = getVolumeControl(guild);
+        VolumeControl volumeControl = getVolumeControl(guild, textChannel);
         volumeControl.setVolume(volume);
         event.reply("볼륨이 " + volume + "%로 설정되었습니다.").queue();
     }


### PR DESCRIPTION
## 📝 작업 내용
> /반복 0: 반복모드 비활성화
/반복 1: 현재 트랙 반복
/반복 2: 대기열 반복
/셔플: 현재 재생중인 곡을 제외한 대기열의 곡들만 셔플
## 🔍 테스트 방법
/반복 입력하면 숫자에 맞게 반복 모드가 설정됨.
![image](https://github.com/user-attachments/assets/12ceab42-c266-44ae-8ac9-b11c64c3ff2e)

/셔플 입력하면 대기열의 곡들이 랜덤으로 섞임.
![image](https://github.com/user-attachments/assets/125609ed-206a-4fa3-a86e-4281c58eea03)
